### PR TITLE
修正“连接设置”中的两个选项的含义

### DIFF
--- a/frpc/webs/Module_frpc.asp
+++ b/frpc/webs/Module_frpc.asp
@@ -729,8 +729,8 @@ function toggle_func() {
                                             <th width="20%"><a class="hintstyle" href="javascript:void(0);" onclick="openssHint(22)">连接设置</a></th>
                                             <td>
                                                 <select id="frpc_common_login_fail_exit" name="frpc_common_login_fail_exit" style="width:165px;margin:0px 0px 0px 2px;" class="input_option" >
-                                                    <option value="true">失败后重复连接</option>
-                                                    <option value="false">失败后退出程序</option>
+                                                    <option value="false">失败后重复连接</option>
+                                                    <option value="true">失败后退出程序</option>
                                                 </select>
                                             </td>
                                         </tr>


### PR DESCRIPTION
- login_fail_exit=**true** 应该是“失败后退出程序”的意思。
- login_fail_exit=**false** 应该是“失败后重复连接”的意思。

在原来的页面中，这两个选项所对应的 option.value 值反了。

Issue #5 中 @zhurifx 提到：

> 连接设置选择失败后退出程序运行成功了，选择重复连接就不行

应该就是这个原因。